### PR TITLE
Fix raspi chrome driver timeout

### DIFF
--- a/jobs_notify/jobs_notify.py
+++ b/jobs_notify/jobs_notify.py
@@ -64,7 +64,7 @@ if __name__ == "__main__":
     targets = [
         # CONFIGURE THE KEY WORDS HERE
         {'key_words': ['Vancouver'], 'found': False},
-        {'key_words': ['Santiago'], 'found': False}
+        {'key_words': ['Taipei'], 'found': False}
     ]
 
     logging.basicConfig(format='%(asctime)s - %(message)s', filename='jobs_notify.log', level=logging.INFO)

--- a/jobs_notify/jobs_notify.py
+++ b/jobs_notify/jobs_notify.py
@@ -16,7 +16,9 @@ def search_amz_newgrad_recent_10(key_words):
         display = Display(visible=0, size=(800, 800))
         display.start()
 
-    driver = webdriver.Chrome()
+    options = webdriver.chrome.options.Options()
+    options.add_argument('--dns-prefetch-disable')
+    driver = webdriver.Chrome(chrome_options=options)
     url = "https://www.amazon.jobs/en/teams/jobs-for-grads?sort=recent"
     content = ''
     try:


### PR DESCRIPTION
According to [this stackoverflow post](https://stackoverflow.com/questions/40273832/selenium-chromedriver-2-25-timeoutexception-cannot-determine-loading-status), it is a selenium bug. Fixed by 
```
chrome_options.add_argument('--dns-prefetch-disable')
```
Tested working properly on my pi~

Resolves #3 